### PR TITLE
Fix semantic release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
This pull request makes a small update to the release workflow configuration by ensuring that `pnpm` is properly set up before installing dependencies.

* Added a step to set up `pnpm` using `pnpm/action-setup@v4.1.0` with version 10 in the `.github/workflows/release.yml` file.